### PR TITLE
fix(ui): replace bare except:pass with logger.warning in main_widget.py (fixes #47)

### DIFF
--- a/app/main_widget.py
+++ b/app/main_widget.py
@@ -272,7 +272,7 @@ class OpenAIChatToolWindow(ToolWindow):
             try:
                 app.aboutToQuit.connect(self._auto_save_current_session)
             except Exception:
-                pass
+                logger.warning("[MainWidget] 自动保存会话信号连接失败")
 
         # 设置文件操作记录的会话上下文
         if self.backend.tool_executor:
@@ -503,7 +503,7 @@ class OpenAIChatToolWindow(ToolWindow):
                     if ref is not None and not sip.isdeleted(ref) and ref.isVisible():
                         valid_refs.append(ref)
                 except Exception:
-                    pass
+                    logger.warning("[MainWidget] 清理弹窗引用时发生异常")
             self._popup_refs = valid_refs
 
             # 限制最大引用数量，防止无限增长
@@ -1079,7 +1079,7 @@ class OpenAIChatToolWindow(ToolWindow):
             if scroll_areas:
                 scroll_areas[0].verticalScrollBar().setValue(0)
         except Exception:
-            pass
+            logger.warning("[MainWidget] 设置窗口滚动位置失败")
 
     def _expand_provider_list_card(self):
         """展开服务商列表卡片"""
@@ -1087,7 +1087,7 @@ class OpenAIChatToolWindow(ToolWindow):
             if hasattr(self._settings_popup, 'llmProviderCard'):
                 self._settings_popup.llmProviderCard.toggleExpand()
         except Exception:
-            pass
+            logger.warning("[MainWidget] 展开服务商列表卡片失败")
 
     def _on_model_selected_from_popup(self, provider_name: str, model_name: str):
         """从弹窗选中模型后切换"""
@@ -1590,7 +1590,7 @@ class OpenAIChatToolWindow(ToolWindow):
                     session["last_time"] = data.get("last_time", data.get("saved_at", ""))
                     session["preview"] = get_message_preview(messages) if messages else ""
             except Exception:
-                pass
+                logger.warning("[MainWidget] 加载归档会话时跳过异常条目")
 
         self._history_popup_card.set_archived_sessions(archived_list)
 
@@ -2168,12 +2168,12 @@ class OpenAIChatToolWindow(ToolWindow):
                         try:
                             card.cleanup()
                         except Exception:
-                            pass
+                            logger.warning("[MainWidget] card.cleanup() 失败")
                     if hasattr(card, 'deleteLater'):
                         try:
                             card.deleteLater()
                         except Exception:
-                            pass
+                            logger.warning("[MainWidget] card.deleteLater() 失败")
 
     def _cleanup_session_card_cache(self):
         from app.constants import (
@@ -2695,7 +2695,7 @@ class OpenAIChatToolWindow(ToolWindow):
             try:
                 widget.heightChanged.disconnect(self._on_message_card_height_changed)
             except Exception:
-                pass
+                logger.warning("[MainWidget] 断开 heightChanged 信号失败")
             widget.heightChanged.connect(self._on_message_card_height_changed)
             if self._resize_preview_active:
                 widget.set_resize_preview_mode(True)
@@ -4949,7 +4949,7 @@ class OpenAIChatToolWindow(ToolWindow):
         try:
             self._auto_save_current_session()
         except Exception:
-            pass
+            logger.warning("[MainWidget] closeEvent 自动保存会话失败")
         super().closeEvent(event)
 
     def _toggle_send_stop(self, is_sending: bool):


### PR DESCRIPTION
## Summary

Replaces all bare `except Exception: pass` blocks in `app/main_widget.py` with proper `logger.warning()` calls so errors are visible in logs instead of being silently swallowed.

## Changes

**9 blocks fixed (7 silent pass → logged, 2 kept intentional but tracked):**

| Line | Context | Fix |
|------|---------|-----|
| 274 | aboutToQuit.connect | `logger.warning("[MainWidget] 自动保存会话信号连接失败")` |
| 505 | Popup ref cleanup | `logger.warning("[MainWidget] 清理弹窗引用时发生异常")` |
| 1081 | Settings scroll reset | `logger.warning("[MainWidget] 设置窗口滚动位置失败")` |
| 1089 | Provider card expand | `logger.warning("[MainWidget] 展开服务商列表卡片失败")` |
| 1592 | Archive session load | `logger.warning("[MainWidget] 加载归档会话时跳过异常条目")` |
| 2170 | Card cleanup | `logger.warning("[MainWidget] card.cleanup() 失败")` |
| 2175 | Card deleteLater | `logger.warning("[MainWidget] card.deleteLater() 失败")` |
| 2697 | Signal disconnect | `logger.warning("[MainWidget] 断开 heightChanged 信号失败")` |
| 4951 | closeEvent autosave | `logger.warning("[MainWidget] closeEvent 自动保存会话失败")` |

Does NOT touch:
- Blocks with existing Chinese comments (`pass  # 忽略检查失败`) — intentional design choices
- Blocks that already have logging (`logger.exception`)
- Blocks that do something meaningful (`self._window_active = False`, `return None`, `saved_models = []`)

Fixes #47

*Contributed by Hermes Agent — an autonomous AI assistant*