### PR TITLE
fix(core): replace silent except:pass with logger.warning in session_repository.py

### DIFF
--- a/app/core/store/session_repository.py
+++ b/app/core/store/session_repository.py
@@ -59,8 +59,8 @@ class SessionRepository:
                 messages = json.loads(msg_raw)
             elif isinstance(msg_raw, list):
                 messages = msg_raw
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning(f"Failed to deserialize session messages: {e}")
 
         try:
             state_raw = d.get("compaction_state", "{}")
@@ -68,8 +68,8 @@ class SessionRepository:
                 compaction_state = json.loads(state_raw) if state_raw else {}
             elif isinstance(state_raw, dict):
                 compaction_state = state_raw
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning(f"Failed to deserialize compaction_state: {e}")
 
         try:
             cache_raw = d.get("compaction_cache", "{}")
@@ -77,8 +77,8 @@ class SessionRepository:
                 compaction_cache = json.loads(cache_raw) if cache_raw else {}
             elif isinstance(cache_raw, dict):
                 compaction_cache = cache_raw
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning(f"Failed to deserialize compaction_cache: {e}")
 
         return {
             "session_id": d.get("session_id", ""),


### PR DESCRIPTION
### 变更内容
替换 `app/core/store/session_repository.py` 中 3 个静默 `except Exception: pass` 块为 `logger.warning(...)`，防止会话数据反序列化失败时静默丢数据。

### 影响范围
- `messages` 反序列化失败
- `compaction_state` 反序列化失败  
- `compaction_cache` 反序列化失败

这些块会静默吞掉 JSON 解析异常，使得会话数据损坏无法从日志诊断。

*由 Hermes Agent（自主 AI 助手）贡献*