### PR TITLE
feat: add session isolation for task status queries and input UX improvements

### DIFF
--- a/app/core/agent.py
+++ b/app/core/agent.py
@@ -46,12 +46,17 @@ class Agent:
     @classmethod
     def from_dict(cls, data: Dict) -> "Agent":
         tools = data.get("tools", {})
+        if isinstance(tools, str):
+            # "Read, Glob, Grep, Bash" → ["Read", "Glob", "Grep", "Bash"]
+            tools = [t.strip() for t in tools.split(",") if t.strip()]
         if isinstance(tools, list):
             tools = {ToolNameMapper.to_native(t): True for t in tools
                      if ToolNameMapper.is_known(t)}
         elif isinstance(tools, dict):
             tools = {ToolNameMapper.to_native(k): v for k, v in tools.items()
                      if ToolNameMapper.is_known(k)}
+        elif tools is None:
+            tools = {}
         return cls(
             name=data.get("name", ""),
             description=data.get("description", ""),

--- a/app/core/builtin_commands.py
+++ b/app/core/builtin_commands.py
@@ -275,7 +275,10 @@ def _generate_tool_restriction_text(meta: dict) -> str:
 
     # 白名单模式（tools 字段）
     if tools:
-        if isinstance(tools, list):
+        if isinstance(tools, str):
+            # "Read, Glob, Grep, Bash" → ["Read", "Glob", "Grep", "Bash"]
+            allowed_list = [t.strip() for t in tools.split(",") if t.strip() and ToolNameMapper.is_known(t.strip())]
+        elif isinstance(tools, list):
             allowed_list = [str(t) for t in tools if ToolNameMapper.is_known(t)]
         elif isinstance(tools, dict):
             allowed_list = [str(k) for k, v in tools.items() if v and ToolNameMapper.is_known(k)]

--- a/app/core/workers/subagent_worker.py
+++ b/app/core/workers/subagent_worker.py
@@ -357,7 +357,7 @@ class SubAgentExecutor(QThread):
             self.finished_with_result.emit(self.task_id, self._last_result)
 
         except Exception as e:
-            logger.error(f"[SubAgentExecutor] run() error: {e}")
+            logger.exception(f"[SubAgentExecutor] run() error: {e}")
             self._execution_error = str(e)
             # 任务出错，保存错误状态
             if self._log_store_callback:
@@ -996,6 +996,7 @@ class SubAgentManager(QObject):
                     "status": db_task.get("status", "unknown"),
                     "agent_name": db_task.get("agent_name", ""),
                     "task_description": db_task.get("task_description", ""),
+                    "session_id": db_task.get("session_id", ""),
                     "result": db_task.get("result", ""),
                     "error": db_task.get("error", ""),
                 }
@@ -1010,7 +1011,8 @@ class SubAgentManager(QObject):
                 "summary": executor.get_summary(),
                 "logs": executor.get_logs(),
                 "found": True,
-                "status": "running"
+                "status": "running",
+                "session_id": getattr(executor, '_task_session_id', ''),
             }
 
         # 检查已完成的任务（内存）
@@ -1028,7 +1030,8 @@ class SubAgentManager(QObject):
                 },
                 "logs": task_info.get("logs", []),
                 "found": True,
-                "status": "finished"
+                "status": "finished",
+                "session_id": task_info.get("session_id", ""),
             }
 
         return {"summary": {}, "logs": [], "found": False, "status": "unknown"}
@@ -1071,34 +1074,52 @@ class SubAgentManager(QObject):
 
         return results
 
-    def get_tasks_status(self, task_ids: List[str]) -> ToolResult:
-        """获取指定任务的状态"""
+    def get_tasks_status(self, task_ids: List[str], session_id: str = None) -> ToolResult:
+        """获取指定任务的状态（会话隔离）
+        
+        Args:
+            session_id: 可选，传入时只返回属于该会话的任务
+        """
+        effective_session = session_id if session_id else self._current_session_id
         tasks_info = []
         for tid in task_ids:
             if tid in self._running_tasks:
                 executor = self._running_tasks[tid]
+                # 会话隔离：检查 running 任务的 session
+                if effective_session:
+                    task_session = getattr(executor, '_task_session_id', '')
+                    if task_session != effective_session:
+                        continue
                 tasks_info.append({
                     "task_id": tid,
                     "status": "running" if executor.isRunning() else "finishing",
                     "agent": executor.agent_name,
                 })
             elif tid in self._finished_tasks:
+                task_info = self._finished_tasks[tid]
+                task_session = task_info.get("session_id", "")
+                # 会话隔离：只返回当前会话的任务
+                # 注意: 当 task_session 为空（旧记录/边缘情况）时，也视为不属于当前会话
+                if effective_session and task_session != effective_session:
+                    continue
                 tasks_info.append({
                     "task_id": tid,
                     "status": "finished",
-                    "agent": self._finished_tasks[tid].get("agent_name", ""),
+                    "agent": task_info.get("agent_name", ""),
                 })
-            else:
-                tasks_info.append({
-                    "task_id": tid,
-                    "status": "unknown",
-                    "agent": "",
-                })
+            # 其他情况（unknown）不返回，隐藏不存在或不属于当前会话的任务
         return ToolResult(True, content={"tasks": tasks_info})
 
     def get_tasks_status_with_details(self, task_ids: List[str], with_log: bool = False,
-                                      with_result: bool = True) -> ToolResult:
-        """获取指定任务的详细状态"""
+                                      with_result: bool = True, session_id: str = None) -> ToolResult:
+        """获取指定任务的详细状态（会话隔离）
+        
+        Args:
+            session_id: 可选，传入时优先使用（解决跨会话查询问题），
+                        不传时回退到 self._current_session_id
+        """
+        # 优先使用传入的 session_id，避免跨会话污染
+        effective_session = session_id if session_id else self._current_session_id
         tasks_info = []
         for tid in task_ids:
             task_data = self.get_task_logs(tid)
@@ -1107,6 +1128,19 @@ class SubAgentManager(QObject):
                     "task_id": tid,
                     "status": "unknown",
                     "agent": "",
+                })
+                continue
+
+            # 会话隔离：检查任务是否属于当前会话
+            task_session = task_data.get("session_id", "")
+            # 注意: 当 task_session 为空（旧记录/边缘情况）时，也视为不属于当前会话
+            if effective_session and task_session != effective_session:
+                # 任务属于其他会话，返回 unknown（不泄露其他会话的任务信息）
+                tasks_info.append({
+                    "task_id": tid,
+                    "status": "unknown",
+                    "agent": "",
+                    "_reason": "任务属于其他会话",
                 })
                 continue
 
@@ -1119,14 +1153,14 @@ class SubAgentManager(QObject):
 
             # running 状态可以反复查，完成或失败只能查一次（按 session 隔离）
             if status not in ("running", "unknown"):
-                session_queried = self._queried_tasks.get(self._current_session_id, set())
+                session_queried = self._queried_tasks.get(effective_session, set())
                 if tid in session_queried:
                     task_info["_already_queried"] = True
                     task_info["_message"] = "已查询过结果，可通过 id 再次查询"
                     tasks_info.append(task_info)
                     continue
                 session_queried.add(tid)
-                self._queried_tasks[self._current_session_id] = session_queried
+                self._queried_tasks[effective_session] = session_queried
 
             # 是否包含结果
             if with_result:
@@ -1161,7 +1195,8 @@ class SubAgentManager(QObject):
         for task_id, task_info in self._finished_tasks.items():
             # 会话隔离：只返回当前会话的任务
             task_session = task_info.get("session_id", "")
-            if target_session and task_session and task_session != target_session:
+            # 注意: 当 task_session 为空（旧记录/边缘情况）时，也视为不属于当前会话
+            if target_session and task_session != target_session:
                 continue
 
             # 跳过当前正在运行的任务（它们应该由 _running_tasks 处理）

--- a/app/main_widget.py
+++ b/app/main_widget.py
@@ -2906,6 +2906,12 @@ class OpenAIChatToolWindow(ToolWindow):
         刷新本地 _valid_configs 并更新 UI。
         """
         self._load_model_configs()
+        # 如果设置卡片当前可见（同窗口），刷新服务商列表
+        if (hasattr(self, '_card_manager') 
+            and self._card_manager.is_card_visible("settings", self._window_id)
+            and hasattr(self, '_settings_popup')
+            and hasattr(self._settings_popup, 'llmProviderCard')):
+            self._settings_popup.llmProviderCard._refresh_items()
         # 如果模型选择卡片当前可见，刷新内容
         if hasattr(self, '_card_manager') and self._card_manager.is_card_visible("model_selector", self._window_id):
             self._load_model_selector_to_card()

--- a/app/tools/task_tools.py
+++ b/app/tools/task_tools.py
@@ -180,7 +180,7 @@ class TaskTools:
             else:
                 # 字符串格式：逗号分隔
                 id_list = [tid.strip() for tid in str(task_ids).split(",") if tid.strip()]
-            return manager.get_tasks_status_with_details(id_list, with_log, with_result)
+            return manager.get_tasks_status_with_details(id_list, with_log, with_result, session_id=session_id)
         else:
             return manager.get_all_active_tasks_with_details(with_log, with_result, session_id=session_id)
 

--- a/app/widgets/bottom_input_area.py
+++ b/app/widgets/bottom_input_area.py
@@ -83,6 +83,7 @@ class SendableTextEdit(TextEdit):
         # 输入历史浏览
         self._history_list: list = []          # 最近输入历史（最新在前）
         self._history_index: int = -1          # -1 = 不在浏览模式
+        self._history_working_line: str = ""   # 进入历史模式时保存的当前输入（退出时恢复）
         self._suppress_slash_trigger: bool = False  # 切换历史时临时阻止 / 触发
 
         # 使用 QTimer.singleShot(0, ...) 在事件循环启动后重置初始化标志
@@ -323,8 +324,48 @@ class SendableTextEdit(TextEdit):
         self.setTextCursor(cursor)
         self.setFocus(Qt.OtherFocusReason)
 
+    def _find_partial_param(self, text: str, param_name: str, cursor_pos: int = None):
+        """在输入文本中查找参数名的部分匹配（优先光标附近）
+        
+        用于智能补全：文本中已有 --subag，点击 --subagent 参数时
+        原地替换为 --subagent，避免变成 --subag --subagent
+
+        Args:
+            text: 输入框全文
+            param_name: 参数名，如 "--subagent", "--model="
+            cursor_pos: 光标位置（可选），存在时优先匹配光标附近的参数
+            
+        Returns:
+            (start, end) 部分匹配范围，或 None
+        """
+        import re
+        clean_name = param_name.rstrip("=")
+        
+        # 如果有光标位置，优先找光标附近一定范围内的匹配
+        if cursor_pos is not None:
+            nearby_match = None
+            for m in re.finditer(r'--[\w-]+', text):
+                token = m.group()
+                if clean_name.startswith(token) and token != clean_name:
+                    # 匹配在光标附近（前后 30 字符范围内）
+                    if abs(m.start() - cursor_pos) <= 30:
+                        if nearby_match is None or abs(m.start() - cursor_pos) < abs(nearby_match.start() - cursor_pos):
+                            nearby_match = m
+            if nearby_match:
+                return (nearby_match.start(), nearby_match.end())
+        
+        # 无光标位置或附近无匹配 → 返回第一个匹配（向后兼容）
+        for m in re.finditer(r'--[\w-]+', text):
+            token = m.group()
+            if clean_name.startswith(token) and token != clean_name:
+                return (m.start(), m.end())
+        return None
+
     def insert_parameter_text(self, param_name: str, param_type: str):
         """在光标处插入参数文本（detail 模式参数补全）
+
+        智能补全：如果输入框中已有部分匹配（如 --subag），
+        则原地替换为完整参数名（--subagent），而非追加。
 
         - flag: 插入 " --param-name "
         - value: 插入 " --param="（等待值选择）
@@ -336,11 +377,24 @@ class SendableTextEdit(TextEdit):
         cursor = self.textCursor()
         text = self.toPlainText()
 
-        # 确定插入位置：光标处 或 文本末尾
+        # 智能补全：部分匹配则原地替换（优先光标附近的匹配）
+        cursor_pos = cursor.position()
+        partial = self._find_partial_param(text, param_name, cursor_pos)
+        if partial:
+            cursor.setPosition(partial[0])
+            cursor.setPosition(partial[1], QTextCursor.KeepAnchor)
+            if param_type == "flag":
+                cursor.insertText(f"{param_name} ")
+            elif param_type == "value":
+                cursor.insertText(f"{param_name}")
+            self.setTextCursor(cursor)
+            self.setFocus(Qt.OtherFocusReason)
+            return
+
+        # 无部分匹配 → 在光标处追加
         pos = cursor.position()
         if pos < 0:
             pos = len(text)
-
         cursor.setPosition(pos)
         if param_type == "flag":
             cursor.insertText(f" {param_name} ")
@@ -369,9 +423,11 @@ class SendableTextEdit(TextEdit):
         self._history_index = -1
 
     def _enter_history_mode(self):
-        """进入历史浏览模式：加载最新一条"""
+        """进入历史浏览模式：保存当前文本，加载最新一条"""
         if not self._history_list:
             return
+        # 保存当前输入为 working line，退出时恢复
+        self._history_working_line = self.toPlainText()
         # 进入历史模式时，隐藏命令卡片
         card = self._get_card()
         if card and card.is_card_visible:
@@ -382,12 +438,21 @@ class SendableTextEdit(TextEdit):
         self._set_history_text()
 
     def _set_history_text(self):
-        """根据当前 history_index 设置输入框文本"""
-        if 0 <= self._history_index < len(self._history_list):
+        """根据当前 history_index 设置输入框文本
+
+        - index >= 0: 显示对应历史条目
+        - index == -1: 恢复 working line（退出历史模式）
+        """
+        if self._history_index < 0:
+            # 退出历史模式，恢复进入时保存的文本
+            self._suppress_slash_trigger = self._history_working_line.strip().startswith("/")
+            self.setPlainText(self._history_working_line)
+            cursor = self.textCursor()
+            cursor.movePosition(QTextCursor.End)
+            self.setTextCursor(cursor)
+            return
+        if self._history_index < len(self._history_list):
             text = self._history_list[self._history_index]
-            # ⚠️ 必须在 setPlainText 之前设置抑制标志！
-            # 否则 textChanged → _on_slash_trigger_check 先执行，标志还没设上
-            # 导致：首次用户按键被错误抑制（标志延后生效），卡片延迟一个按键才出现
             self._suppress_slash_trigger = text.strip().startswith("/")
             self.setPlainText(text)
             # 选中全部文本，方便继续编辑
@@ -414,9 +479,9 @@ class SendableTextEdit(TextEdit):
             return
 
         if new_index < 0:
-            # 超过最新条目，退出浏览模式
+            # 超过最新条目 → 退出浏览模式，恢复 working line
             self._history_index = -1
-            self.clear()
+            self._set_history_text()
             return
 
         self._history_index = new_index
@@ -458,7 +523,12 @@ class SendableTextEdit(TextEdit):
         # 文本变化时总是需要调整高度，不管是否在停止模式
         if not getattr(self, '_initializing', False):
             self._adjust_height_to_content()
-        # detail 模式参数同步（安全兜底，_on_slash_trigger_check 也会调）
+        # 历史模式：用户修改了当前显示的文本 → 退出历史模式，↑↓ 不再切历史
+        if self._history_index >= 0:
+            idx = self._history_index
+            if idx < len(self._history_list) and self._history_list[idx] != self.toPlainText():
+                self._reset_history_mode()
+        # detail 模式参数同步
         self._sync_detail_params()
 
     def _adjust_height_to_content(self):

--- a/app/widgets/cards/settings/llm_settings_card.py
+++ b/app/widgets/cards/settings/llm_settings_card.py
@@ -669,10 +669,10 @@ class LLMSettingsCard(SystemCardFrame):
         if hasattr(self, "llmApiEnabledCard"):
             self.llmApiEnabledCard.setContent(f"http://localhost:{port}/docs")
 
-    def show(self):
+    def showEvent(self, event):
         if hasattr(self, 'llmProviderCard'):
             self.llmProviderCard._refresh_items()
-        super().show()
+        super().showEvent(event)
 
     def set_opacity(self, opacity: float):
         """设置透明度（保留接口，暂不实现动态透明度）"""


### PR DESCRIPTION
## Changes

### Task Status Session Isolation
- Add `session_id` parameter to `get_tasks_status()` and `get_tasks_status_with_details()` for session isolation
- Add `session_id` field to task query results across running/finished/db tasks
- Pass `session_id` through from `task_tools.py` → `SubAgentManager`

### Input UX Improvements
- **History mode**: Preserve working line when navigating away and back; auto-exit history when user edits displayed text
- **Smart parameter completion**: Replace partial `--flag` with full `--flag` when inserting, preferring matches near cursor

### Tools Field Format
- Support comma-separated string format for `tools` field in `Agent.from_dict()` (e.g., `"Read, Glob, Grep"`)
- Mirror same parsing in `_generate_tool_restriction_text()` for prompt generation

### UI Fixes
- `LLMSettingsCard`: Change `show()` to `showEvent(event)` override for correct Qt lifecycle
- `main_widget._on_providers_config_changed()`: Refresh `llmProviderCard` items when settings card is visible

### Logging
- Replace `logger.error` with `logger.exception` in `SubAgentExecutor.run()` for full stack traces